### PR TITLE
Fix Example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,33 +5,37 @@ Using the [cultofcoders:grapher](https://github.com/cult-of-coders/grapher) quer
 
 createQueryContainer
 --------------------
-```
-// Tasks.jsx
+```js
+// TaskList.jsx
 import React from 'react';
 import Tasks from '/imports/api/tasks/collection.js';
 import { createQueryContainer } from 'meteor/cultofcoders:grapher-react';
 
 const query = Tasks.createQuery({
-    title: 1
-})
+    title: 1,
+});
 
-const Tasks = ({loading, error, tasks}) => (
-    _.map(tasks, task => <div>{task.title}</div>)
+const TaskList = ({loading, error, tasks}) => (
+  <div>
+    {
+      _.map(tasks, task => <div key={task._id}>{task.title}</div>)
+    }
+  </div>    
 );
 
-export default createQueryContainer(query, Tasks, {
-    reactive: true // defaults to false, will use pub/sub system
-    dataProp: 'tasks' // defaults to 'data',
-    single: false // defaults to false, when you expect a single document, like you filter by _id, use this. 
-})
+export default createQueryContainer(query, TaskList, {
+    reactive: true, // defaults to false, will use pub/sub system
+    dataProp: 'tasks', // defaults to 'data'
+    single: false, // defaults to false, when you expect a single document, like you filter by _id, use this. 
+});
 ```
 
 You can pass params directly in the constructor, these params will be passed to the query.
 
-```
-import Tasks from './Tasks.jsx';
+```js
+import TaskList from './Tasks.jsx';
 
 export default () => {
-    return <Tasks params={{isActive: true}} anyOtherProp="willBePassedToComponent" />
+    return <TaskList params={{isActive: true}} anyOtherProp="willBePassedToComponent" />
 }
 ```


### PR DESCRIPTION
I noticed a couple of minor issues with the example for `createQueryContainer` in the README. This PR adapts it slightly such that it works. 