### PR TITLE
Ssr

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,56 @@ export default withQuery((props) => {
     loadingComponent: AnotherLoadingComponent,
 })(UserProfile)
 ```
+### Server Side Rendering
+
+One common challenge with server-side rendering is hydrating client. The data used in the view needs to be available when the page loads so that React can hydrate the DOM with no differences. This technique will allow you send all of the necessary data with the initial HTML payload. The code below works with `withQuery` to track and hydrate data automatically. Works with static queries and subscriptions.
+
+On the server:
+
+```jsx harmony
+import { onPageLoad } from 'meteor/server-render'
+import { SSRDataStore } from 'meteor/cultofcoders:grapher-react'
+
+onPageLoad(async sink => {
+	const store = new SSRDataStore()
+
+	sink.renderIntoElementById(
+		'root',
+		renderToString(
+			store.collectData(<App />)
+		)
+    )
+    
+	const storeTags = store.getScriptTags()
+	sink.appendToBody(storeTags)
+})
+```
+
+On the client:
+
+```jsx harmony
+import { DataHydrator } from 'meteor/cultofcoders:grapher-react'
+
+Meteor.startup(async () => {
+	await DataHydrator.load()
+	ReactDOM.hydrate(<App />, document.getElementById('root'))
+})
+```
+
+Use `withQuery` on a component:
+
+```jsx harmony
+const SomeLoader = ({ data, isLoading, error }) => {
+	if (error) {
+		return <div>{error.reason}</div>
+	}
+
+	return <SomeList items={data} />
+}
+
+export default withQuery(
+	props => {
+		return GetSome.clone()
+	},
+)(SomeLoader)
+```

--- a/lib/DataHydrator.js
+++ b/lib/DataHydrator.js
@@ -1,0 +1,45 @@
+import { Promise } from 'meteor/promise'
+import { generateQueryId } from './utils.js';
+
+export default {
+
+    decodeData(data) {
+        const decodedEjsonString = decodeURIComponent(data);
+        if (!decodedEjsonString) return null;
+
+        return EJSON.parse(decodedEjsonString);
+    },
+
+    load(optns) {
+        const defaults = {
+            selfDestruct: 3000
+        }
+        const options = Object.assign({}, defaults, optns)
+
+        return new Promise((resolve, reject) => {
+            // Retrieve the payload from the DOM
+            const dom = document.querySelectorAll(
+                'script[type="text/grapher-data"]',
+                document
+            );
+            const dataString = dom && dom.length > 0 ? dom[0].innerHTML : '';
+            const data = this.decodeData(dataString) || {};
+            window.grapherQueryStore = data
+
+            // Self destruct the store so that dynamically loaded modules
+            // do not pull from the store in the future
+            setTimeout(() => {
+                window.grapherQueryStore = {};
+            }, options.selfDestruct)
+
+            resolve(data);
+        });
+    },
+
+    getQueryData(query) {
+        const id = generateQueryId(query);
+        const data = window.grapherQueryStore[id]
+        return data
+    }
+    
+}

--- a/lib/SSRDataStore.js
+++ b/lib/SSRDataStore.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types';
+import { EJSON } from 'meteor/ejson';
+import { generateQueryId } from './utils.js';
+export const SSRDataStoreContext = React.createContext(null);
+
+class DataStore {
+    storage = {}
+
+    add(query, value) {
+        const key = generateQueryId(query)
+        this.storage[key] = value
+    }
+
+    getData() {
+        return this.storage
+    }
+}
+
+export default class SSRDataStore{
+    constructor() {
+        this.store = new DataStore()
+    }
+
+    collectData(children) {
+        return <SSRDataStoreContext.Provider value={this.store}>{children}</SSRDataStoreContext.Provider>
+    }
+
+    encodeData(data) {
+        data = EJSON.stringify(data)
+        return encodeURIComponent(data)
+    }
+
+    getScriptTags() {
+        const data = this.store.getData()
+        
+        return `<script type="text/grapher-data">${this.encodeData(data)}</script>`
+    }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,3 @@
+export const generateQueryId = function (query) {
+    return `${query.queryName}::${EJSON.stringify(query.params)}`;
+}

--- a/lib/withReactiveQuery.js
+++ b/lib/withReactiveQuery.js
@@ -1,5 +1,7 @@
 import {withTracker} from 'meteor/react-meteor-data';
 import {ReactiveVar} from 'meteor/reactive-var';
+import DataHydrator from './DataHydrator.js';
+import { Meteor } from 'meteor/meteor';
 
 /**
  * Wraps the query and provides reactive data fetching utility
@@ -14,24 +16,48 @@ export default function withReactiveContainer(handler, config, QueryComponent) {
     return withTracker((props) => {
         const query = handler(props);
 
-        const subscriptionHandle = query.subscribe({
-            onStop(err) {
-                if (err) {
-                    subscriptionError.set(err);
+        let isLoading
+        let data
+        let error
+
+        // For server-side-rendering, immediately fetch the data
+        // and save it in the data store for this request
+        
+        if(Meteor.isServer) {
+            data = query.fetch();
+            isLoading = false;
+            props.dataStore.add(query, data);
+        } else {
+            const subscriptionHandle = query.subscribe({
+                onStop(err) {
+                    if (err) {
+                        subscriptionError.set(err);
+                    }
+                },
+                onReady() {
+                    subscriptionError.set(null);
                 }
-            },
-            onReady() {
-                subscriptionError.set(null);
+            });
+    
+            isLoading = !subscriptionHandle.ready();
+
+            // Check the SSR query store for data 
+            if(Meteor.isClient && window && window.grapherQueryStore) {
+                const ssrData = DataHydrator.getQueryData(query);
+                if(ssrData) {
+                    isLoading = false;
+                    data = ssrData;
+                }
             }
-        });
 
-        const isReady = subscriptionHandle.ready();
-
-        const data = query.fetch();
-
+            if(!data) {
+                data = query.fetch();
+            }
+        }
+        
         return {
             grapher: {
-                isLoading: !isReady,
+                isLoading,
                 data,
                 error: subscriptionError,
             },

--- a/lib/withStaticQuery.js
+++ b/lib/withStaticQuery.js
@@ -51,7 +51,11 @@ export default function withStaticQueryContainer(WrappedComponent) {
 
         componentDidMount() {
             const {query, config} = this.props;
-            this.fetch(query);
+
+            // Do not fetch is we already have the data from SSR hydration
+            if(this.state.isLoading === true) {
+                this.fetch(query);
+            }
 
             if (config.pollingMs) {
                 this.pollingInterval = setInterval(() => {

--- a/lib/withStaticQuery.js
+++ b/lib/withStaticQuery.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import getDisplayName from './getDisplayName';
+import { Meteor } from 'meteor/meteor';
+import DataHydrator from './DataHydrator.js';
 
 export default function withStaticQueryContainer(WrappedComponent) {
     /**
@@ -7,11 +9,40 @@ export default function withStaticQueryContainer(WrappedComponent) {
      * This is a standard pattern in HOCs
      */
     class GrapherStaticQueryContainer extends React.Component {
-        state = {
-            isLoading: true,
-            error: null,
-            data: [],
-        };
+        constructor(props) {
+            super(props);
+
+            this.state = {
+                isLoading: true,
+                error: null,
+                data: [],
+            };
+
+            const { query } = props;
+
+            // Check the SSR query store for data 
+            if(Meteor.isClient && window && window.grapherQueryStore) {
+                const data = DataHydrator.getQueryData(query);
+                if(data) {
+                    this.state = {
+                        isLoading: false,
+                        data
+                    };
+                    
+                }
+            }
+
+            // For server-side-rendering, immediately fetch the data
+            // and save it in the data store for this request
+            if(Meteor.isServer) {
+                const data = query.fetch();
+                this.state = {
+                    isLoading: false,
+                    data
+                };
+                props.dataStore.add(query, data);
+            }
+        }
 
         componentWillReceiveProps(nextProps) {
             const {query} = nextProps;

--- a/main.client.js
+++ b/main.client.js
@@ -16,3 +16,7 @@ export {
 export {
     default as createQueryContainer
 } from './legacy/createQueryContainer.js';
+
+export {
+    default as DataHydrator
+} from './lib/DataHydrator.js';

--- a/main.server.js
+++ b/main.server.js
@@ -16,3 +16,7 @@ export {
 export {
     default as createQueryContainer
 } from './legacy/createQueryContainer.js';
+
+export {
+    default as SSRDataStore
+} from './lib/SSRDataStore.js';

--- a/package.js
+++ b/package.js
@@ -20,6 +20,7 @@ Package.onUse(function (api) {
         'react-meteor-data@0.2.15',
         'cultofcoders:grapher@1.2.8_1',
         'tmeasday:check-npm-versions@0.2.0',
+        'ejson'
     ]);
 
     api.mainModule('main.client.js', 'client');


### PR DESCRIPTION
Target issue: https://github.com/cult-of-coders/grapher/issues/199

Adds data hydration support for server-side rendering.

Hey @theodorDiaconu 
I'd love to get your opinion on this approach:

Uses a similar approach to `styled-components`. Creates a new data store for every request, and uses the new React Context API to expose it to all `withQuery` components. `withStaticQuery` and `withReactiveQuery` contain logic to immediately fetch a query result, store it, and retrieve it again on the client.

1. Subscription data is fetched twice (once on server, once on client). I can improve this in the future by marking the subscription as ready with the same techniques `FastRender` uses, however it may require modification of grapher core (I haven't looked yet). Static Queries are not loaded twice.
2. The client-side hydration data store self destructs after 3 seconds (configurable). The hydration store should be considered old and invalid after the initial request is served. Any dynamically loaded components should be fetching from the server instead of from the store. 
3. This does not require modifying `grapher` core in any way.
4. Using a per-request store instead of a global store makes it easier and more secure to accumulate data. No userId checking required.

There are no tests for this repository, so I wasn't able to run any, but I did test static, reactive, and singular queries pretty extensively.