### PR TITLE
Remove practicalmeteor:chai dependency

### DIFF
--- a/package.js
+++ b/package.js
@@ -35,7 +35,7 @@ Package.onTest(function(api) {
         'mongo',
     ]);
 
-    api.use(['cultofcoders:mocha', 'practicalmeteor:chai']);
+    api.use(['cultofcoders:mocha']);
 
     api.addFiles('__tests__/main.server.js', 'server');
     api.addFiles('__tests__/main.client.js', 'client');


### PR DESCRIPTION
It isn't used anywhere anyways, only regular `chai` is used in tests. Might solve publish issue from #32