### PR TITLE
Provide shouldRefetch option to prevent refetching of static queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const query = createQuery('usersWithEmails', {
       <tr>
     <td>shouldRefetch</td>
     <td>(currentProps, nextProps) => Boolean</td>
-    <td>`true`</td>
+    <td>`undefined`</td>
     <td>
         For static queries only, provides a hook into `componentWillReceiveProps` to determine whether the query should be refetched or not. The function will be called with nextProps and currentProps as arguments.
     </td>

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ const query = createQuery('usersWithEmails', {
         For static (`reactive = false`) queries only, sets `isLoading` to true every time you call refetch until the data is loaded. Set this to false to only get `isLoading` on the initial fetch.
     </td>
   </tr>
+      <tr>
+    <td>shouldRefetch</td>
+    <td>(currentProps, nextProps) => Boolean</td>
+    <td>`true`</td>
+    <td>
+        For static queries only, provides a hook into `componentWillReceiveProps` to determine whether the query should be refetched or not. The function will be called with nextProps and currentProps as arguments.
+    </td>
+  </tr>
 </table>
 
 ### Simple Usage

--- a/lib/checkOptions.js
+++ b/lib/checkOptions.js
@@ -10,6 +10,7 @@ export default function(options) {
         loadingComponent: Match.Maybe(Match.Any),
         dataProp: Match.Maybe(String),
         loadOnRefetch: Match.Maybe(Boolean),
+        shouldRefetch: Match.Maybe(Function),
     });
 
     if (options.reactive && options.poll) {

--- a/lib/withStaticQuery.js
+++ b/lib/withStaticQuery.js
@@ -17,11 +17,9 @@ export default function withStaticQueryContainer(config) {
             componentWillReceiveProps(nextProps) {
                 const { query } = nextProps;
                 
-                if (config.shouldRefetch && config.shouldRefetch(nextProps)) {
-                    this.fetch(query);
-                }
-                
                 if (!config.shouldRefetch) {
+                    this.fetch(query);
+                } else if (config.shouldRefetch(nextProps)) {
                     this.fetch(query);
                 }
             }

--- a/lib/withStaticQuery.js
+++ b/lib/withStaticQuery.js
@@ -16,7 +16,14 @@ export default function withStaticQueryContainer(config) {
 
             componentWillReceiveProps(nextProps) {
                 const { query } = nextProps;
-                this.fetch(query);
+                
+                if (config.shouldRefetch && config.shouldRefetch(nextProps)) {
+                    this.fetch(query);
+                }
+                
+                if (!config.shouldRefetch) {
+                    this.fetch(query);
+                }
             }
 
             componentDidMount() {

--- a/lib/withStaticQuery.js
+++ b/lib/withStaticQuery.js
@@ -19,7 +19,7 @@ export default function withStaticQueryContainer(config) {
                 
                 if (!config.shouldRefetch) {
                     this.fetch(query);
-                } else if (config.shouldRefetch(nextProps)) {
+                } else if (config.shouldRefetch(this.props, nextProps)) {
                     this.fetch(query);
                 }
             }


### PR DESCRIPTION
Static queries are refetched every time new props are passed through the withQuery HOC, this can lead to unnecessary updates which you can't easily prevent.

This PR adds a new config variable `shouldRefetch` that is a function which can decide if a query should be fetched again.