### PR TITLE
Add loadOnRefetch for reactive queries

### DIFF
--- a/lib/withReactiveQuery.js
+++ b/lib/withReactiveQuery.js
@@ -10,7 +10,9 @@ import {ReactiveVar} from 'meteor/reactive-var';
  */
 export default function withReactiveContainer(handler, config, QueryComponent) {
     let subscriptionError = new ReactiveVar();
-
+    const { loadOnRefetch = true } = config;
+    let hasBeenReady = false;
+    
     return withTracker((props) => {
         const query = handler(props);
 
@@ -28,10 +30,11 @@ export default function withReactiveContainer(handler, config, QueryComponent) {
         const isReady = subscriptionHandle.ready();
 
         const data = query.fetch();
+        const isLoading = loadOnRefetch ? !isReady : !hasBeenReady && !isReady;
 
         return {
             grapher: {
-                isLoading: !isReady,
+                isLoading,
                 data,
                 error: subscriptionError,
             },

--- a/lib/withReactiveQuery.js
+++ b/lib/withReactiveQuery.js
@@ -28,6 +28,10 @@ export default function withReactiveContainer(handler, config, QueryComponent) {
         });
 
         const isReady = subscriptionHandle.ready();
+        
+        if (!loadOnRefetch && !hasBeenReady && isReady) {
+            hasBeenReady = true;
+        }
 
         const data = query.fetch();
         const isLoading = loadOnRefetch ? !isReady : !hasBeenReady && !isReady;


### PR DESCRIPTION
This PR makes loadOnRefetch work for reactive queries as well, such that if you change the query, like when you change `$body`, it does not pass isLoading down. 

Extends #32.