### PR TITLE
When polling, query should be refreshed from props

### DIFF
--- a/lib/withStaticQuery.js
+++ b/lib/withStaticQuery.js
@@ -30,7 +30,7 @@ export default function withStaticQueryContainer(config) {
 
                 if (config.pollingMs) {
                     this.pollingInterval = setInterval(() => {
-                        this.fetch(query);
+                        this.fetch();
                     }, config.pollingMs);
                 }
             }
@@ -40,6 +40,10 @@ export default function withStaticQueryContainer(config) {
             }
 
             fetch(query) {
+                if (!query) {
+                    query = this.props.query;
+                }
+
                 query.fetch((error, data) => {
                     if (error) {
                         this.setState({


### PR DESCRIPTION
Currently, if you change the query when polling, it refetches the initial query.