### PR TITLE
update dependencies

### DIFF
--- a/package.js
+++ b/package.js
@@ -18,16 +18,16 @@ Package.onUse(function(api) {
         'tracker',
         'check',
         'reactive-var',
-        'react-meteor-data@0.2.15',
-        'cultofcoders:grapher@1.3.9_3',
-        'tmeasday:check-npm-versions@0.2.0',
+        'react-meteor-data@2.0.1',
+        'cultofcoders:grapher@1.3.19',
+        'tmeasday:check-npm-versions@0.3.2',
     ]);
 
     api.mainModule('main.client.js', 'client');
     api.mainModule('main.server.js', 'server');
 });
 
-Package.onTest(function(api) {
+Package.onTest(function (api) {
     api.use([
         'cultofcoders:grapher-react',
         'cultofcoders:grapher',


### PR DESCRIPTION
current `react-meteor-data` dependency prevents updating to the latest version. Updated other outdated but non blocking dependencies while I was at it. 